### PR TITLE
Tweak RPM calculation to improve accuracy

### DIFF
--- a/Knock_Shield_Interrupt_Example.ino
+++ b/Knock_Shield_Interrupt_Example.ino
@@ -136,7 +136,7 @@ void loop() {
     if (knock_percentage >= 80) digitalWrite(LED_LIMIT, HIGH); else digitalWrite(LED_LIMIT, LOW);
 
     //Calculate engine speed.
-    float engineSpeed = 60000 / (currentTime * numberofCylinders / 2000);
+    float engineSpeed = (60000 * 2000) / (currentTime * numberofCylinders)
 
     //Calculate time constant.
     timeConstant = map(engineSpeed, 1000, 9000, SPU_SET_MAX_TIME, SPU_SET_MIN_TIME);


### PR DESCRIPTION
Hi,

First off, thanks for creating these examples, they made it really simple to get up and running with your knock shield.

Just one thing I spotted while using this example: when calculating RPM, the division of the integers in the brackets introduces a fairly large rounding error, swapping the calculation around removes this.

Old behavior:

```
18:35:51.562 -> SPU KNOCK LEVEL: 44%, ENGINE SPEED: 2222 RPM, KNOCK WINDOW: 13924us, TIME CONSTANT: 0xD5
18:35:51.699 -> SPU KNOCK LEVEL: 45%, ENGINE SPEED: 2222 RPM, KNOCK WINDOW: 13924us, TIME CONSTANT: 0xD5
18:35:51.803 -> SPU KNOCK LEVEL: 45%, ENGINE SPEED: 2222 RPM, KNOCK WINDOW: 13700us, TIME CONSTANT: 0xD5
18:35:51.939 -> SPU KNOCK LEVEL: 44%, ENGINE SPEED: 2307 RPM, KNOCK WINDOW: 13440us, TIME CONSTANT: 0xD5
18:35:52.075 -> SPU KNOCK LEVEL: 44%, ENGINE SPEED: 2307 RPM, KNOCK WINDOW: 13216us, TIME CONSTANT: 0xD5
18:35:52.176 -> SPU KNOCK LEVEL: 44%, ENGINE SPEED: 2307 RPM, KNOCK WINDOW: 13124us, TIME CONSTANT: 0xD5
```

Tweaked:

```
18:37:07.272 -> SPU KNOCK LEVEL: 46%, ENGINE SPEED: 2180 RPM, KNOCK WINDOW: 13620us, TIME CONSTANT: 0xD5
18:37:07.374 -> SPU KNOCK LEVEL: 45%, ENGINE SPEED: 2229 RPM, KNOCK WINDOW: 13456us, TIME CONSTANT: 0xD5
18:37:07.514 -> SPU KNOCK LEVEL: 43%, ENGINE SPEED: 2299 RPM, KNOCK WINDOW: 13044us, TIME CONSTANT: 0xD5
18:37:07.652 -> SPU KNOCK LEVEL: 43%, ENGINE SPEED: 2311 RPM, KNOCK WINDOW: 12980us, TIME CONSTANT: 0xD5
18:37:07.754 -> SPU KNOCK LEVEL: 42%, ENGINE SPEED: 2319 RPM, KNOCK WINDOW: 12932us, TIME CONSTANT: 0xD5
18:37:07.891 -> SPU KNOCK LEVEL: 42%, ENGINE SPEED: 2355 RPM, KNOCK WINDOW: 12724us, TIME CONSTANT: 0xD4
```

Cheers,
Tom